### PR TITLE
Upgrade @rules_proto and cleanup jarindexer

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,11 +8,9 @@ workspace_deps()
 # @rules_proto
 # ----------------------------------------------------
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
 rules_proto_dependencies()
-
-rules_proto_toolchains()
 
 # ----------------------------------------------------
 # Go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,10 +39,13 @@ gazelle_dependencies()
 # @build_stack_rules_proto
 # ----------------------------------------------------
 
-# defining this in the WORKSPACE despite 'bazel query //external:org_golang_google_grpc --output build' saying it's
-# still coming from go_repos.bzl.  I don't understand this one...  Without it org_golang_google_grpc
-# is falling back to 1.27.0.
-# Must occur before gazelle_protobuf_extension_go_deps() macro call.
+register_toolchains("@build_stack_rules_proto//toolchain:standard")
+
+# defining go_repository for @org_golang_google_grpc this in the WORKSPACE
+# It must occur before gazelle_protobuf_extension_go_deps() macro call.
+# I don't understand this one...  Despite 'bazel query //external:org_golang_google_grpc --output build'
+# saying it's still coming from go_repos.bzl, that does not appear to be the case.
+# Without this override org_golang_google_grpc is falling back to 1.27.0.
 go_repository(
     name = "org_golang_google_grpc",
     build_file_proto_mode = "disable_global",
@@ -50,8 +53,6 @@ go_repository(
     sum = "h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=",
     version = "v1.42.0",
 )
-
-register_toolchains("@build_stack_rules_proto//toolchain:standard")
 
 load("@build_stack_rules_proto//:go_deps.bzl", "gazelle_protobuf_extension_go_deps")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 rules_proto_dependencies()
 
 # ----------------------------------------------------
-# Go
+# @io_bazel_rules_go
 # ----------------------------------------------------
 
 load(
@@ -27,7 +27,7 @@ go_rules_dependencies()
 go_register_toolchains(version = "1.18.2")
 
 # ----------------------------------------------------
-# Gazelle
+# @bazel_gazelle
 # ----------------------------------------------------
 # gazelle:repository_macro go_repos.bzl%go_repositories
 
@@ -35,9 +35,14 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
+# ----------------------------------------------------
+# @build_stack_rules_proto
+# ----------------------------------------------------
+
 # defining this in the WORKSPACE despite 'bazel query //external:org_golang_google_grpc --output build' saying it's
 # still coming from go_repos.bzl.  I don't understand this one...  Without it org_golang_google_grpc
 # is falling back to 1.27.0.
+# Must occur before gazelle_protobuf_extension_go_deps() macro call.
 go_repository(
     name = "org_golang_google_grpc",
     build_file_proto_mode = "disable_global",
@@ -46,19 +51,11 @@ go_repository(
     version = "v1.42.0",
 )
 
-# ----------------------------------------------------
-# @build_stack_rules_proto
-# ----------------------------------------------------
-
 register_toolchains("@build_stack_rules_proto//toolchain:standard")
 
 load("@build_stack_rules_proto//:go_deps.bzl", "gazelle_protobuf_extension_go_deps")
 
 gazelle_protobuf_extension_go_deps()
-
-# ----------------------------------------------------
-# Go
-# ----------------------------------------------------
 
 load("@build_stack_rules_proto//deps:go_core_deps.bzl", "go_core_deps")
 
@@ -69,7 +66,7 @@ load("//:go_repos.bzl", "go_repositories")
 go_repositories()
 
 # ----------------------------------------------------
-# NodeJS
+# @build_bazel_rules_nodejs
 # ----------------------------------------------------
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
@@ -79,15 +76,11 @@ node_repositories()
 register_toolchains("//tools/toolchains:nodejs")
 
 # ----------------------------------------------------
-# Maven
+# @maven
 #
 # Note: maven dependencies should only be required for
 # tests.
 # ----------------------------------------------------
-
-# load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
-
-# protobuf_deps()
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
@@ -131,7 +124,7 @@ bind(
 )
 
 # ----------------------------------------------------
-# Scala
+# @io_bazel_rules_scala
 # ----------------------------------------------------
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,6 +5,16 @@ load(":workspace_deps.bzl", "workspace_deps")
 workspace_deps()
 
 # ----------------------------------------------------
+# @rules_proto
+# ----------------------------------------------------
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
+# ----------------------------------------------------
 # Go
 # ----------------------------------------------------
 
@@ -39,7 +49,7 @@ go_repository(
 )
 
 # ----------------------------------------------------
-# build_stack_rules_proto
+# @build_stack_rules_proto
 # ----------------------------------------------------
 
 register_toolchains("@build_stack_rules_proto//toolchain:standard")

--- a/build/stack/gazelle/scala/jarindex/BUILD.bazel
+++ b/build/stack/gazelle/scala/jarindex/BUILD.bazel
@@ -30,8 +30,8 @@ proto_java_library(
     name = "jarindex_java_library",
     srcs = ["jarindex.srcjar"],
     visibility = ["//visibility:public"],
-    exports = ["@com_google_protobuf//:protobuf_java"],
-    deps = ["@com_google_protobuf//:protobuf_java"],
+    exports = ["@protobuf_java_jar//jar"],
+    deps = ["@protobuf_java_jar//jar"],
 )
 
 go_library(

--- a/cmd/jarindexer/BUILD.bazel
+++ b/cmd/jarindexer/BUILD.bazel
@@ -5,7 +5,7 @@ java_library(
     deps = [
         "//build/stack/gazelle/scala/jarindex:jarindex_java_library",
         "@classgraph_jar//jar",
-        "@com_google_protobuf//:protobuf_java",
+        "@protobuf_java_jar//jar",
     ],
 )
 
@@ -30,7 +30,7 @@ java_test(
     deps = [
         ":jarindexer",
         "//build/stack/gazelle/scala/jarindex:jarindex_java_library",
-        "@com_google_protobuf//:protobuf_java_util",
+        "@protobuf_java_jar//jar_util",
     ],
 )
 

--- a/cmd/jarindexer/BUILD.bazel
+++ b/cmd/jarindexer/BUILD.bazel
@@ -30,7 +30,8 @@ java_test(
     deps = [
         ":jarindexer",
         "//build/stack/gazelle/scala/jarindex:jarindex_java_library",
-        "@protobuf_java_jar//jar_util",
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
     ],
 )
 

--- a/rules/jar_class_index.bzl
+++ b/rules/jar_class_index.bzl
@@ -140,7 +140,7 @@ E.g. ["@maven//:io_grpc_grpc_api"] means, "in the case where io.grpc.CallCredent
             executable = True,
         ),
         "_jarindexer": attr.label(
-            default = Label("//cmd/jarindexer"),
+            default = Label("//cmd/jarindexer:jarindexer_bin"),
             cfg = "exec",
             executable = True,
         ),

--- a/rules/java_indexer_aspect.bzl
+++ b/rules/java_indexer_aspect.bzl
@@ -298,27 +298,11 @@ def _get_compile_flags(dep):
 def build_jar_index(ctx, target, jar):
     """Builds the java package manifest for the given source files."""
 
-    ijar = ctx.actions.declare_file(jar.short_path.replace("/", "-"))
-
-    # input_file = ctx.actions.declare_file(target.label.name + ".jar.json")
     output_file = ctx.actions.declare_file(target.label.name + ".jarindex.json")
 
     ctx.actions.run(
-        executable = ctx.executable._ijar,
-        inputs = [jar],
-        outputs = [ijar],
-        arguments = [
-            "--target_label",
-            str(ctx.label),
-            jar.path,
-            ijar.path,
-        ],
-        mnemonic = "Ijar",
-    )
-
-    ctx.actions.run(
         mnemonic = "JarIndexer",
-        progress_message = "Indexing " + ijar.basename,
+        progress_message = "Indexing " + jar.basename,
         executable = ctx.executable._jarindexer,
         arguments = [
             "--label",
@@ -327,7 +311,7 @@ def build_jar_index(ctx, target, jar):
             output_file.path,
             jar.path,
         ],
-        inputs = [ijar, jar],
+        inputs = [jar],
         outputs = [output_file],
     )
 
@@ -654,12 +638,6 @@ java_indexer_aspect = aspect(
             default = Label("//cmd/jarindexer"),
             cfg = "exec",
             executable = True,
-        ),
-        "_ijar": attr.label(
-            default = Label("@bazel_tools//tools/jdk:ijar"),
-            executable = True,
-            cfg = "exec",
-            allow_files = True,
         ),
     },
     fragments = ["cpp", "java"],

--- a/rules/java_indexer_aspect.bzl
+++ b/rules/java_indexer_aspect.bzl
@@ -316,42 +316,18 @@ def build_jar_index(ctx, target, jar):
         mnemonic = "Ijar",
     )
 
-    # ctx.actions.write(
-    #     content = json.encode(struct(
-    #         label = str(target.label),
-    #         filename = ijar_file.path,
-    #     )),
-    #     output = input_file,
-    # )
-
-    # args = [
-    #     "--input_file",
-    #     input_file.path,
-    #     "--output_file",
-    #     output_file.path,
-    # ]
-
-    # ctx.actions.run(
-    #     mnemonic = "IJarIndexer",
-    #     progress_message = "Extracting symbols from: " + jar.basename,
-    #     executable = ctx.executable._jarindexer,
-    #     arguments = args,
-    #     inputs = [input_file, ijar_file],
-    #     outputs = [output_file],
-    # )
-
     ctx.actions.run(
-        mnemonic = "JarIndexer2",
+        mnemonic = "JarIndexer",
         progress_message = "Indexing " + ijar.basename,
-        executable = ctx.executable._jarindexer2,
+        executable = ctx.executable._jarindexer,
         arguments = [
             "--label",
             str(ctx.label),
             "--output_file",
             output_file.path,
-            ijar.path,
+            jar.path,
         ],
-        inputs = [ijar],
+        inputs = [ijar, jar],
         outputs = [output_file],
     )
 
@@ -674,13 +650,8 @@ java_indexer_aspect = aspect(
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
-        # "_jarindexer": attr.label(
-        #     default = Label("//cmd/jarindexer"),
-        #     cfg = "exec",
-        #     executable = True,
-        # ),
-        "_jarindexer2": attr.label(
-            default = Label("//cmd/jarindexer:jarindexer2"),
+        "_jarindexer": attr.label(
+            default = Label("//cmd/jarindexer"),
             cfg = "exec",
             executable = True,
         ),

--- a/workspace_deps.bzl
+++ b/workspace_deps.bzl
@@ -25,8 +25,14 @@ def workspace_deps():
     build_bazel_rules_nodejs()  # via <TOP>
     rules_jvm_external()
     io_bazel_rules_scala()
+    protobuf_core_deps()
     viz_js_lite()
-    com_google_protobuf()
+
+def protobuf_core_deps():
+    bazel_skylib()  # via com_google_protobuf
+    rules_python()  # via com_google_protobuf
+    zlib()  # via com_google_protobuf
+    com_google_protobuf()  # via <TOP>
 
 def io_bazel_rules_go():
     # Release: v0.35.0
@@ -200,6 +206,41 @@ def protobuf_java_jar():
         name = "protobuf_java_jar",
         sha256 = "0b8581ad810d2dfaefd0dcfbf1569b1450448650238d7e2fd6b176c932d08c95",
         url = "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.8/protobuf-java-3.21.8.jar",
+    )
+
+def bazel_skylib():
+    _maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "ebdf850bfef28d923a2cc67ddca86355a449b5e4f38b0a70e584dc24e5984aa6",
+        strip_prefix = "bazel-skylib-f80bc733d4b9f83d427ce3442be2e07427b2cc8d",
+        urls = [
+            "https://github.com/bazelbuild/bazel-skylib/archive/f80bc733d4b9f83d427ce3442be2e07427b2cc8d.tar.gz",
+        ],
+    )
+
+def rules_python():
+    _maybe(
+        http_archive,
+        name = "rules_python",
+        sha256 = "8cc0ad31c8fc699a49ad31628273529ef8929ded0a0859a3d841ce711a9a90d5",
+        strip_prefix = "rules_python-c7e068d38e2fec1d899e1c150e372f205c220e27",
+        urls = [
+            "https://github.com/bazelbuild/rules_python/archive/c7e068d38e2fec1d899e1c150e372f205c220e27.tar.gz",
+        ],
+    )
+
+def zlib():
+    _maybe(
+        http_archive,
+        name = "zlib",
+        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        strip_prefix = "zlib-1.2.11",
+        urls = [
+            "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
+            "https://zlib.net/zlib-1.2.11.tar.gz",
+        ],
+        build_file = "@build_stack_rules_proto//third_party:zlib.BUILD",
     )
 
 def com_google_protobuf():

--- a/workspace_deps.bzl
+++ b/workspace_deps.bzl
@@ -18,8 +18,6 @@ def workspace_deps():
     build_bazel_rules_nodejs()  # via <TOP>
     rules_jvm_external()
     io_bazel_rules_scala()
-
-    # protobuf_core_deps()
     viz_js_lite()
 
 def io_bazel_rules_go():
@@ -140,58 +138,6 @@ def io_bazel_rules_scala():
             "https://github.com/bazelbuild/rules_scala/archive/2437e40131072cadc1628726775ff00fa3941a4a.tar.gz",
         ],
     )
-
-# def protobuf_core_deps():
-#     bazel_skylib()  # via com_google_protobuf
-#     rules_python()  # via com_google_protobuf
-#     zlib()  # via com_google_protobuf
-#     com_google_protobuf()  # via <TOP>
-
-# def bazel_skylib():
-#     _maybe(
-#         http_archive,
-#         name = "bazel_skylib",
-#         sha256 = "ebdf850bfef28d923a2cc67ddca86355a449b5e4f38b0a70e584dc24e5984aa6",
-#         strip_prefix = "bazel-skylib-f80bc733d4b9f83d427ce3442be2e07427b2cc8d",
-#         urls = [
-#             "https://github.com/bazelbuild/bazel-skylib/archive/f80bc733d4b9f83d427ce3442be2e07427b2cc8d.tar.gz",
-#         ],
-#     )
-
-# def rules_python():
-#     _maybe(
-#         http_archive,
-#         name = "rules_python",
-#         sha256 = "8cc0ad31c8fc699a49ad31628273529ef8929ded0a0859a3d841ce711a9a90d5",
-#         strip_prefix = "rules_python-c7e068d38e2fec1d899e1c150e372f205c220e27",
-#         urls = [
-#             "https://github.com/bazelbuild/rules_python/archive/c7e068d38e2fec1d899e1c150e372f205c220e27.tar.gz",
-#         ],
-#     )
-
-# def zlib():
-#     _maybe(
-#         http_archive,
-#         name = "zlib",
-#         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-#         strip_prefix = "zlib-1.2.11",
-#         urls = [
-#             "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-#             "https://zlib.net/zlib-1.2.11.tar.gz",
-#         ],
-#         build_file = "@build_stack_rules_proto//third_party:zlib.BUILD",
-#     )
-
-# def com_google_protobuf():
-#     _maybe(
-#         http_archive,
-#         name = "com_google_protobuf",
-#         sha256 = "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
-#         strip_prefix = "protobuf-3.14.0",
-#         urls = [
-#             "https://github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz",
-#         ],
-#     )
 
 def viz_js_lite():
     # HTTP/2.0 200 OK

--- a/workspace_deps.bzl
+++ b/workspace_deps.bzl
@@ -5,21 +5,21 @@ def _maybe(repo_rule, name, **kwargs):
         repo_rule(name = name, **kwargs)
 
 def language_scala_deps():
+    protobuf_java_jar()
     classgraph_jar()
     scalameta_parsers()
 
 def workspace_deps():
-    io_bazel_rules_go()  # via bazel_gazelle
-
-    classgraph_jar()
-    scalameta_parsers()
-    bazel_gazelle()  # via <TOP>
     rules_proto()  # via <TOP>
+    io_bazel_rules_go()  # via bazel_gazelle
+    language_scala_deps()
+    bazel_gazelle()  # via <TOP>
     build_stack_rules_proto()
     build_bazel_rules_nodejs()  # via <TOP>
     rules_jvm_external()
     io_bazel_rules_scala()
-    protobuf_core_deps()
+
+    # protobuf_core_deps()
     viz_js_lite()
 
 def io_bazel_rules_go():
@@ -80,14 +80,20 @@ def local_bazel_gazelle():
     )
 
 def rules_proto():
+    # Commit: f7a30f6f80006b591fa7c437fe5a951eb10bcbcf
+    # Date: 2021-02-09 14:25:06 +0000 UTC
+    # URL: https://github.com/bazelbuild/rules_proto/commit/f7a30f6f80006b591fa7c437fe5a951eb10bcbcf
+    #
+    # Merge pull request #77 from Yannic/proto_descriptor_set_rule
+    #
+    # Create proto_descriptor_set
+    # Size: 14397 (14 kB)
     _maybe(
         http_archive,
         name = "rules_proto",
         sha256 = "9fc210a34f0f9e7cc31598d109b5d069ef44911a82f507d5a88716db171615a8",
         strip_prefix = "rules_proto-f7a30f6f80006b591fa7c437fe5a951eb10bcbcf",
-        urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/f7a30f6f80006b591fa7c437fe5a951eb10bcbcf.tar.gz",
-        ],
+        urls = ["https://github.com/bazelbuild/rules_proto/archive/f7a30f6f80006b591fa7c437fe5a951eb10bcbcf.tar.gz"],
     )
 
 def build_stack_rules_proto():
@@ -135,57 +141,57 @@ def io_bazel_rules_scala():
         ],
     )
 
-def protobuf_core_deps():
-    bazel_skylib()  # via com_google_protobuf
-    rules_python()  # via com_google_protobuf
-    zlib()  # via com_google_protobuf
-    com_google_protobuf()  # via <TOP>
+# def protobuf_core_deps():
+#     bazel_skylib()  # via com_google_protobuf
+#     rules_python()  # via com_google_protobuf
+#     zlib()  # via com_google_protobuf
+#     com_google_protobuf()  # via <TOP>
 
-def bazel_skylib():
-    _maybe(
-        http_archive,
-        name = "bazel_skylib",
-        sha256 = "ebdf850bfef28d923a2cc67ddca86355a449b5e4f38b0a70e584dc24e5984aa6",
-        strip_prefix = "bazel-skylib-f80bc733d4b9f83d427ce3442be2e07427b2cc8d",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/archive/f80bc733d4b9f83d427ce3442be2e07427b2cc8d.tar.gz",
-        ],
-    )
+# def bazel_skylib():
+#     _maybe(
+#         http_archive,
+#         name = "bazel_skylib",
+#         sha256 = "ebdf850bfef28d923a2cc67ddca86355a449b5e4f38b0a70e584dc24e5984aa6",
+#         strip_prefix = "bazel-skylib-f80bc733d4b9f83d427ce3442be2e07427b2cc8d",
+#         urls = [
+#             "https://github.com/bazelbuild/bazel-skylib/archive/f80bc733d4b9f83d427ce3442be2e07427b2cc8d.tar.gz",
+#         ],
+#     )
 
-def rules_python():
-    _maybe(
-        http_archive,
-        name = "rules_python",
-        sha256 = "8cc0ad31c8fc699a49ad31628273529ef8929ded0a0859a3d841ce711a9a90d5",
-        strip_prefix = "rules_python-c7e068d38e2fec1d899e1c150e372f205c220e27",
-        urls = [
-            "https://github.com/bazelbuild/rules_python/archive/c7e068d38e2fec1d899e1c150e372f205c220e27.tar.gz",
-        ],
-    )
+# def rules_python():
+#     _maybe(
+#         http_archive,
+#         name = "rules_python",
+#         sha256 = "8cc0ad31c8fc699a49ad31628273529ef8929ded0a0859a3d841ce711a9a90d5",
+#         strip_prefix = "rules_python-c7e068d38e2fec1d899e1c150e372f205c220e27",
+#         urls = [
+#             "https://github.com/bazelbuild/rules_python/archive/c7e068d38e2fec1d899e1c150e372f205c220e27.tar.gz",
+#         ],
+#     )
 
-def zlib():
-    _maybe(
-        http_archive,
-        name = "zlib",
-        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-        strip_prefix = "zlib-1.2.11",
-        urls = [
-            "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-            "https://zlib.net/zlib-1.2.11.tar.gz",
-        ],
-        build_file = "@build_stack_rules_proto//third_party:zlib.BUILD",
-    )
+# def zlib():
+#     _maybe(
+#         http_archive,
+#         name = "zlib",
+#         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+#         strip_prefix = "zlib-1.2.11",
+#         urls = [
+#             "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
+#             "https://zlib.net/zlib-1.2.11.tar.gz",
+#         ],
+#         build_file = "@build_stack_rules_proto//third_party:zlib.BUILD",
+#     )
 
-def com_google_protobuf():
-    _maybe(
-        http_archive,
-        name = "com_google_protobuf",
-        sha256 = "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
-        strip_prefix = "protobuf-3.14.0",
-        urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz",
-        ],
-    )
+# def com_google_protobuf():
+#     _maybe(
+#         http_archive,
+#         name = "com_google_protobuf",
+#         sha256 = "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
+#         strip_prefix = "protobuf-3.14.0",
+#         urls = [
+#             "https://github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz",
+#         ],
+#     )
 
 def viz_js_lite():
     # HTTP/2.0 200 OK
@@ -228,4 +234,16 @@ def classgraph_jar():
         name = "classgraph_jar",
         sha256 = "ece8abfe1277450a8b95e57fc56991dca1fd42ffefdad88f65fe171ac576f604",
         url = "https://repo1.maven.org/maven2/io/github/classgraph/classgraph/4.8.149/classgraph-4.8.149.jar",
+    )
+
+def protobuf_java_jar():
+    # bzl use jar https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.8/protobuf-java-3.21.8.jar
+    # Last-Modified: Tue, 18 Oct 2022 19:48:19 GMT
+    # X-Checksum-Md5: 39d238b47a0278795884e92e1c966796
+    # X-Checksum-Sha1: 2a1eebb74b844d9ccdf1d22eb2f57cec709698a9
+    # Size: 1671407 (1.7 MB)
+    http_jar(
+        name = "protobuf_java_jar",
+        sha256 = "0b8581ad810d2dfaefd0dcfbf1569b1450448650238d7e2fd6b176c932d08c95",
+        url = "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.8/protobuf-java-3.21.8.jar",
     )

--- a/workspace_deps.bzl
+++ b/workspace_deps.bzl
@@ -5,11 +5,18 @@ def _maybe(repo_rule, name, **kwargs):
         repo_rule(name = name, **kwargs)
 
 def language_scala_deps():
+    """language_scala_deps loads a subset of dependencies
+
+    when @build_stack_scala_gazelle//language/scala is used from another
+    repository.
+    """
     protobuf_java_jar()
     classgraph_jar()
     scalameta_parsers()
 
 def workspace_deps():
+    """workspace_deps loads all dependencies for the workspace
+    """
     rules_proto()  # via <TOP>
     io_bazel_rules_go()  # via bazel_gazelle
     language_scala_deps()
@@ -19,6 +26,7 @@ def workspace_deps():
     rules_jvm_external()
     io_bazel_rules_scala()
     viz_js_lite()
+    com_google_protobuf()
 
 def io_bazel_rules_go():
     # Release: v0.35.0
@@ -192,4 +200,15 @@ def protobuf_java_jar():
         name = "protobuf_java_jar",
         sha256 = "0b8581ad810d2dfaefd0dcfbf1569b1450448650238d7e2fd6b176c932d08c95",
         url = "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.21.8/protobuf-java-3.21.8.jar",
+    )
+
+def com_google_protobuf():
+    _maybe(
+        http_archive,
+        name = "com_google_protobuf",
+        sha256 = "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
+        strip_prefix = "protobuf-3.14.0",
+        urls = [
+            "https://github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz",
+        ],
     )


### PR DESCRIPTION
The previous alternative @com_google_protobuf//:protobuf_java introduces a possible conflicting dependency with the host workspace.