### PR TITLE
Add -scala_existing_rule flag

### DIFF
--- a/language/scala/BUILD.bazel
+++ b/language/scala/BUILD.bazel
@@ -108,6 +108,7 @@ gazelle_binary(
 go_test(
     name = "scala_test",
     srcs = [
+        "flags_test.go",
         "glob_test.go",
         "import_origin_test.go",
         "import_resolver_test.go",
@@ -134,6 +135,7 @@ go_test(
         "@build_stack_rules_proto//pkg/goldentest",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/language/scala/flags.go
+++ b/language/scala/flags.go
@@ -10,12 +10,19 @@ import (
 	"github.com/stackb/scala-gazelle/pkg/crossresolve"
 )
 
+const (
+	totalPackageCountFlagName  = "total_package_count"
+	scalaResolversFlagName     = "scala_resolvers"
+	scalaExistingRulesFlagName = "scala_existing_rule"
+)
+
 // RegisterFlags implements part of the language.Language interface
 func (sl *scalaLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 	getOrCreateScalaConfig(c) // ignoring return value, only want side-effect
 
-	fs.IntVar(&sl.totalPackageCount, "total_package_count", 0, "number of total packages for the workspace (used for progress estimation)")
-	fs.StringVar(&sl.resolverNames, "scala_resolvers", "maven,proto,source", "comma-separated list of scala cross-resolver implementations to enable")
+	fs.IntVar(&sl.totalPackageCount, totalPackageCountFlagName, 0, "number of total packages for the workspace (used for progress estimation)")
+	fs.StringVar(&sl.resolverNames, scalaResolversFlagName, "maven,proto,source", "comma-separated list of scala cross-resolver implementations to enable")
+	fs.Var(&sl.scalaExistingRules, scalaExistingRulesFlagName, "LOAD%NAME mapping for a custom scala_existing_rule implementation (e.g. '@io_bazel_rules_scala//scala:scala.bzl%scala_library'")
 
 	// all known cross-resolvers can register flags, but do it in repeatable order
 	resolvers := crossresolve.Resolvers().ByName()
@@ -34,6 +41,9 @@ func (sl *scalaLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Confi
 
 // CheckFlags implements part of the language.Language interface
 func (sl *scalaLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
+	if err := parseScalaExistingRules(sl.scalaExistingRules); err != nil {
+		return err
+	}
 	for _, name := range strings.Split(sl.resolverNames, ",") {
 		resolver, err := crossresolve.Resolvers().LookupResolver(name)
 		if err != nil {
@@ -49,5 +59,30 @@ func (sl *scalaLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 		return err
 	}
 
+	return nil
+}
+
+func parseScalaExistingRules(rules []string) error {
+	for _, fqn := range rules {
+		parts := strings.SplitN(fqn, "%", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid -scala_existing_rule flag value: wanted '%%' separated string, got %q", fqn)
+		}
+		load := parts[0]
+		kind := parts[1]
+		isBinaryRule := strings.Contains(kind, "binary") || strings.Contains(kind, "test")
+		Rules().MustRegisterRule(fqn, &scalaExistingRule{load, kind, isBinaryRule})
+	}
+	return nil
+}
+
+type stringSliceFlags []string
+
+func (i *stringSliceFlags) String() string {
+	return strings.Join(*i, ",")
+}
+
+func (i *stringSliceFlags) Set(value string) error {
+	*i = append(*i, value)
 	return nil
 }

--- a/language/scala/flags_test.go
+++ b/language/scala/flags_test.go
@@ -1,0 +1,66 @@
+package scala
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseScalaExistingRules(t *testing.T) {
+	for name, tc := range map[string]struct {
+		rules        []string
+		wantErr      error
+		wantLoadInfo rule.LoadInfo
+		wantKindInfo rule.KindInfo
+		check        func(t *testing.T)
+	}{
+		"degenerate": {},
+		"invalid flag value": {
+			rules:   []string{"@io_bazel_rules_scala//scala:scala.bzl#scala_binary"},
+			wantErr: fmt.Errorf(`invalid -scala_existing_rule flag value: wanted '%%' separated string, got "@io_bazel_rules_scala//scala:scala.bzl#scala_binary"`),
+		},
+		"valid flag value": {
+			rules: []string{"//custom/scala:scala.bzl%scala_binary"},
+			wantLoadInfo: rule.LoadInfo{
+				Name:    "//custom/scala:scala.bzl",
+				Symbols: []string{"scala_binary"},
+			},
+			wantKindInfo: rule.KindInfo{
+				ResolveAttrs: map[string]bool{"deps": true},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := parseScalaExistingRules(tc.rules)
+			if !equalError(tc.wantErr, err) {
+				t.Fatal("errors: want:", tc.wantErr, "got:", err)
+			}
+			if tc.wantErr != nil {
+				return
+			}
+			if tc.check != nil {
+				tc.check(t)
+			}
+			for _, ruleID := range tc.rules {
+				if info, err := Rules().LookupRule(ruleID); err != nil {
+					t.Fatal(err)
+				} else {
+					if diff := cmp.Diff(tc.wantLoadInfo, info.LoadInfo()); diff != "" {
+						t.Errorf("loadInfo (-want +got):\n%s", diff)
+					}
+					if diff := cmp.Diff(tc.wantKindInfo, info.KindInfo()); diff != "" {
+						t.Errorf("kindInfo (-want +got):\n%s", diff)
+					}
+				}
+			}
+		})
+	}
+}
+
+// equalError reports whether errors a and b are considered equal.
+// They're equal if both are nil, or both are not nil and a.Error() == b.Error().
+func equalError(a, b error) bool {
+	return a == nil && b == nil || a != nil && b != nil && a.Error() == b.Error()
+}

--- a/language/scala/language.go
+++ b/language/scala/language.go
@@ -84,6 +84,8 @@ type scalaLang struct {
 	totalRules int
 	// progress is the progress interface
 	progress mobyprogress.Output
+	// scalaExistingRules is the value of the scala_existing_rule repeatable flag
+	scalaExistingRules stringSliceFlags
 }
 
 // Name implements part of the language.Language interface

--- a/language/scala/scala_existing_rule.go
+++ b/language/scala/scala_existing_rule.go
@@ -43,16 +43,6 @@ func init() {
 	mustRegister("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", false)
 	mustRegister("@io_bazel_rules_scala//scala:scala.bzl", "scala_macro_library", false)
 	mustRegister("@io_bazel_rules_scala//scala:scala.bzl", "scala_test", true)
-
-	mustRegister("@io_bazel_rules_scala//scala:scala.bzl", "_scala_library", false)
-	mustRegister("//bazel_tools:scala.bzl", "scala_app", false)
-	mustRegister("//bazel_tools:scala.bzl", "scala_app_test", true)
-	mustRegister("//bazel_tools:scala.bzl", "scala_app_library", false)
-	mustRegister("//bazel_tools:scala.bzl", "trumid_scala_library", false)
-	mustRegister("//bazel_tools:scala.bzl", "trumid_scala_test", true)
-	mustRegister("//bazel_tools:scala.bzl", "classic_scala_app", false)
-	mustRegister("//bazel_tools:scala.bzl", "scala_e2e_app", false)
-	mustRegister("//bazel_tools:scala.bzl", "scala_e2e_test", true)
 }
 
 // scalaExistingRule implements RuleResolver for scala-kind rules that are


### PR DESCRIPTION
This PR adds a flag that allows users to register custom scala_existing_rule example for custom rule ID (load%kind)