### PR TITLE
new directive `gazelle:scala_explain_srcs`

### DIFF
--- a/language/scala/language.go
+++ b/language/scala/language.go
@@ -90,7 +90,8 @@ func (*scalaLang) KnownDirectives() []string {
 		ruleDirective,
 		overrideDirective,
 		implicitImportDirective,
-		scalaExplainDependencies,
+		scalaExplainDeps,
+		scalaExplainSrcs,
 		mapKindImportNameDirective,
 	}
 }

--- a/language/scala/language_test.go
+++ b/language/scala/language_test.go
@@ -18,6 +18,7 @@ func ExampleLanguage_KnownDirectives() {
 	// scala_rule
 	// override
 	// implicit_import
-	// scala_explain_dependencies
+	// scala_explain_deps
+	// scala_explain_srcs
 	// map_kind_import_name
 }

--- a/language/scala/rule_index.go
+++ b/language/scala/rule_index.go
@@ -1,17 +1,27 @@
 package scala
 
 import (
+	"log"
+
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
+const debugLookupRule = false
+
 // LookupRule implements part of the crossresolve.RuleIndex interface
 func (sl *scalaLang) LookupRule(from label.Label) (*rule.Rule, bool) {
 	r, ok := sl.allRules[from]
+	if debugLookupRule {
+		log.Printf("scalaLang.LookupRule(%q) -> %t", from, ok)
+	}
 	return r, ok
 }
 
 // recordRule sets the given rule in the global label->rule map.
 func (sl *scalaLang) recordRule(from label.Label, r *rule.Rule) {
+	if debugLookupRule {
+		log.Printf("scalaLang.recordRule(%q) [%s]", from, r.Kind())
+	}
 	sl.allRules[from] = r
 }

--- a/language/scala/scala_config.go
+++ b/language/scala/scala_config.go
@@ -22,8 +22,10 @@ const (
 	overrideDirective = "override"
 	// implicitImportDirective adds additional imports for resolution
 	implicitImportDirective = "implicit_import"
-	// scala_explain_dependencies prints the reason why deps are included.
-	scalaExplainDependencies = "scala_explain_dependencies"
+	// scala_explain_deps prints the reason why deps are included.
+	scalaExplainDeps = "scala_explain_deps"
+	// scala_expand_srcs replaces the "srcs" attribute with actual srcs, if enabled.
+	scalaExplainSrcs = "scala_explain_srcs"
 	// mapKindImportNameDirective allows renaming of resolved labels.
 	mapKindImportNameDirective = "map_kind_import_name"
 )
@@ -44,8 +46,10 @@ type scalaConfig struct {
 	implicitImports []*implicitImportSpec
 	// map kinds are parsed from 'gazelle:map_kind_import_name
 	mapKindImportNames map[string]mapKindImportNameSpec
-	// explainDependencies is a flag to print additional comments on deps & exports
-	explainDependencies bool
+	// explainDeps is a flag to print additional comments on deps & exports
+	explainDeps bool
+	// explainSrcs is a flag to print additional comments on srcs
+	explainSrcs bool
 }
 
 // newScalaConfig initializes a new scalaConfig.
@@ -87,7 +91,7 @@ func getOrCreateScalaConfig(ruleIndex crossresolve.RuleIndex, config *config.Con
 // clone copies this config to a new one.
 func (c *scalaConfig) clone(config *config.Config, rel string) *scalaConfig {
 	clone := newScalaConfig(c.ruleIndex, config, rel)
-	clone.explainDependencies = c.explainDependencies
+	clone.explainDeps = c.explainDeps
 	for k, v := range c.rules {
 		clone.rules[k] = v.clone()
 	}
@@ -129,8 +133,10 @@ func (c *scalaConfig) parseDirectives(directives []rule.Directive) (err error) {
 			c.parseOverrideDirective(d)
 		case implicitImportDirective:
 			c.parseImplicitImportDirective(d)
-		case scalaExplainDependencies:
-			c.parseScalaExplainDependencies(d)
+		case scalaExplainDeps:
+			c.parseScalaExplainDeps(d)
+		case scalaExplainSrcs:
+			c.parseScalaExplainSrcs(d)
 		case mapKindImportNameDirective:
 			c.parseMapKindImportNameDirective(d)
 		}
@@ -206,13 +212,22 @@ func (c *scalaConfig) parseMapKindImportNameDirective(d rule.Directive) {
 	c.mapKindImportNames[kind] = mapKindImportNameSpec{src: src, dst: dst}
 }
 
-func (c *scalaConfig) parseScalaExplainDependencies(d rule.Directive) {
+func (c *scalaConfig) parseScalaExplainDeps(d rule.Directive) {
 	parts := strings.Fields(d.Value)
 	if len(parts) != 1 {
-		log.Printf("invalid gazelle:scala_explain_dependencies directive: expected 1+ parts, got %d (%v)", len(parts), parts)
+		log.Printf("invalid gazelle:%s directive: expected 1+ parts, got %d (%v)", scalaExplainDeps, len(parts), parts)
 		return
 	}
-	c.explainDependencies = parts[0] == "true"
+	c.explainDeps = parts[0] == "true"
+}
+
+func (c *scalaConfig) parseScalaExplainSrcs(d rule.Directive) {
+	parts := strings.Fields(d.Value)
+	if len(parts) != 1 {
+		log.Printf("invalid gazelle:%s directive: expected 1+ parts, got %d (%v)", scalaExplainSrcs, len(parts), parts)
+		return
+	}
+	c.explainSrcs = parts[0] == "true"
 }
 
 func (c *scalaConfig) getOrCreateRuleConfig(config *config.Config, name string) (*RuleConfig, error) {

--- a/language/scala/scala_config.go
+++ b/language/scala/scala_config.go
@@ -92,6 +92,7 @@ func getOrCreateScalaConfig(ruleIndex crossresolve.RuleIndex, config *config.Con
 func (c *scalaConfig) clone(config *config.Config, rel string) *scalaConfig {
 	clone := newScalaConfig(c.ruleIndex, config, rel)
 	clone.explainDeps = c.explainDeps
+	clone.explainSrcs = c.explainSrcs
 	for k, v := range c.rules {
 		clone.rules[k] = v.clone()
 	}

--- a/language/scala/scala_config_test.go
+++ b/language/scala/scala_config_test.go
@@ -166,7 +166,7 @@ func TestScalaConfigParseScalaExplainDependencies(t *testing.T) {
 		"degenerate": {},
 		"typical example": {
 			directives: []rule.Directive{
-				{Key: scalaExplainDependencies, Value: "true"},
+				{Key: scalaExplainDeps, Value: "true"},
 			},
 			want: true,
 		},
@@ -176,7 +176,7 @@ func TestScalaConfigParseScalaExplainDependencies(t *testing.T) {
 			if testutil.ExpectError(t, tc.wantErr, err) {
 				return
 			}
-			got := sc.explainDependencies
+			got := sc.explainDeps
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("(-want +got):\n%s", diff)
 			}
@@ -184,6 +184,32 @@ func TestScalaConfigParseScalaExplainDependencies(t *testing.T) {
 	}
 }
 
+func TestScalaConfigParseScalaExplainSrcs(t *testing.T) {
+	for name, tc := range map[string]struct {
+		directives []rule.Directive
+		wantErr    error
+		want       bool
+	}{
+		"degenerate": {},
+		"typical example": {
+			directives: []rule.Directive{
+				{Key: scalaExplainSrcs, Value: "true"},
+			},
+			want: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			sc, err := parseTestDirectives("", tc.directives...)
+			if testutil.ExpectError(t, tc.wantErr, err) {
+				return
+			}
+			got := sc.explainSrcs
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 func TestScalaConfigParseMapKindImportNameDirective(t *testing.T) {
 	for name, tc := range map[string]struct {
 		directives []rule.Directive

--- a/language/scala/scala_existing_rule.go
+++ b/language/scala/scala_existing_rule.go
@@ -280,7 +280,7 @@ func commentUnresolvedImports(unresolved ImportOriginMap, r *rule.Rule, attrName
 	for _, imp := range imports {
 		origin := unresolved[imp]
 		srcs.Comment().Before = append(srcs.Comment().Before, build.Comment{
-			Token: fmt.Sprintf("# ❌ unresolved: %s (%s)", imp, origin.String()),
+			Token: fmt.Sprintf("# unresolved: %s (%s)", imp, origin.String()),
 		})
 	}
 }
@@ -430,7 +430,7 @@ func explainDependencies(str *build.StringExpr, imports ImportOriginMap) {
 	}
 	reasons = protoc.DeduplicateAndSort(reasons)
 	for _, reason := range reasons {
-		str.Comments.Before = append(str.Comments.Before, build.Comment{Token: "# ✅ " + reason})
+		str.Comments.Before = append(str.Comments.Before, build.Comment{Token: "# " + reason})
 	}
 }
 

--- a/language/scala/scala_existing_rule.go
+++ b/language/scala/scala_existing_rule.go
@@ -247,7 +247,7 @@ func (s *scalaExistingRuleRule) Resolve(c *config.Config, ix *resolve.RuleIndex,
 		depsExpr := makeLabeledListExpr(c, r.Kind(), keep, r.Attr("deps"), from, resolved)
 		r.SetAttr("deps", depsExpr)
 
-		if len(unresolved) > 0 && sc.explainDependencies {
+		if len(unresolved) > 0 && sc.explainDeps {
 			commentUnresolvedImports(unresolved, r, "srcs")
 		}
 	}
@@ -401,7 +401,7 @@ func makeLabeledListExpr(c *config.Config, kind string, shouldKeep func(build.Ex
 	for id, dep := range keys {
 		imports := keeps[dep]
 		str := &build.StringExpr{Value: dep}
-		if sc.explainDependencies {
+		if sc.explainDeps {
 			explainDependencies(str, imports)
 			if debug {
 				str.Comments.Suffix = []build.Comment{{Token: fmt.Sprintf("# %d", id)}}

--- a/language/scala/scala_existing_rule_test.go
+++ b/language/scala/scala_existing_rule_test.go
@@ -148,7 +148,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
 			want: `scala_library(
     name = "test",
     deps = [
-        # com.typesafe.scalalogging.LazyLogging (comment)
+        # ✅ com.typesafe.scalalogging.LazyLogging (comment)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )
@@ -163,7 +163,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
 			want: `scala_library(
     name = "test",
     deps = [
-        # com.typesafe.scalalogging.LazyLogging (comment)
+        # ✅ com.typesafe.scalalogging.LazyLogging (comment)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )
@@ -202,7 +202,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
     name = "test",
     deps = [
         ":foo",  # keep
-        # com.typesafe.scalalogging.LazyLogging (comment)
+        # ✅ com.typesafe.scalalogging.LazyLogging (comment)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )
@@ -431,7 +431,7 @@ scala_library(
 scala_library(
     name = "test",
     srcs =
-    # unresolved: com.foo.Bar (direct from Main.scala)
+    # ❌ unresolved: com.foo.Bar (direct from Main.scala)
     ["Main.scala"],
     deps = [],
 )`,

--- a/language/scala/scala_existing_rule_test.go
+++ b/language/scala/scala_existing_rule_test.go
@@ -148,7 +148,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
 			want: `scala_library(
     name = "test",
     deps = [
-        # ✅ com.typesafe.scalalogging.LazyLogging (comment)
+        # com.typesafe.scalalogging.LazyLogging (comment)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )
@@ -163,7 +163,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
 			want: `scala_library(
     name = "test",
     deps = [
-        # ✅ com.typesafe.scalalogging.LazyLogging (comment)
+        # com.typesafe.scalalogging.LazyLogging (comment)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )
@@ -202,7 +202,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
     name = "test",
     deps = [
         ":foo",  # keep
-        # ✅ com.typesafe.scalalogging.LazyLogging (comment)
+        # com.typesafe.scalalogging.LazyLogging (comment)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )
@@ -431,7 +431,7 @@ scala_library(
 scala_library(
     name = "test",
     srcs =
-    # ❌ unresolved: com.foo.Bar (direct from Main.scala)
+    # unresolved: com.foo.Bar (direct from Main.scala)
     ["Main.scala"],
     deps = [],
 )`,

--- a/language/scala/scala_existing_rule_test.go
+++ b/language/scala/scala_existing_rule_test.go
@@ -141,7 +141,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
 		},
 		"simple+reason": {
 			in:         `scala_library(name="test")`,
-			directives: []rule.Directive{{Key: "scala_explain_dependencies", Value: "true"}},
+			directives: []rule.Directive{{Key: "scala_explain_deps", Value: "true"}},
 			resolved: map[string]string{
 				"com.typesafe.scalalogging.LazyLogging": "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
 			},
@@ -156,7 +156,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
 		},
 		"simple+reason+deduplicate": {
 			in:         `scala_library(name="test")`,
-			directives: []rule.Directive{{Key: "scala_explain_dependencies", Value: "true"}},
+			directives: []rule.Directive{{Key: "scala_explain_deps", Value: "true"}},
 			resolved: map[string]string{
 				"com.typesafe.scalalogging.LazyLogging": "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
 			},
@@ -177,7 +177,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
     ],
 )
 `,
-			directives: []rule.Directive{{Key: "scala_explain_dependencies", Value: "true"}},
+			directives: []rule.Directive{{Key: "scala_explain_deps", Value: "true"}},
 			want: `scala_library(
     name = "test",
     deps = [
@@ -194,7 +194,7 @@ func TestMakeLabeledListExpr(t *testing.T) {
     ],
 )
 `,
-			directives: []rule.Directive{{Key: "scala_explain_dependencies", Value: "true"}},
+			directives: []rule.Directive{{Key: "scala_explain_deps", Value: "true"}},
 			resolved: map[string]string{
 				"com.typesafe.scalalogging.LazyLogging": "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
 			},

--- a/language/scala/testdata/maven_direct_deps/BUILD.in
+++ b/language/scala/testdata/maven_direct_deps/BUILD.in
@@ -1,7 +1,8 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 # gazelle:scala_rule scala_library implementation @io_bazel_rules_scala//scala:scala.bzl%scala_library
-# gazelle:scala_explain_dependencies true
+# gazelle:scala_explain_deps true
+# gazelle:scala_explain_srcs true
 
 scala_library(
     name = "app",

--- a/language/scala/testdata/maven_direct_deps/BUILD.out
+++ b/language/scala/testdata/maven_direct_deps/BUILD.out
@@ -10,7 +10,7 @@ scala_library(
     # Main.scala - com.typesafe.scalalogging.LazyLogging (direct)
     ["Main.scala"],
     deps = [
-        # com.typesafe.scalalogging.LazyLogging (direct from Main.scala)
+        # ✅ com.typesafe.scalalogging.LazyLogging (direct from Main.scala)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )

--- a/language/scala/testdata/maven_direct_deps/BUILD.out
+++ b/language/scala/testdata/maven_direct_deps/BUILD.out
@@ -1,10 +1,12 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 # gazelle:scala_rule scala_library implementation @io_bazel_rules_scala//scala:scala.bzl%scala_library
-# gazelle:scala_explain_dependencies true
+# gazelle:scala_explain_deps true
+# gazelle:scala_explain_srcs true
 
 scala_library(
     name = "app",
+    # Main.scala - com.typesafe.scalalogging.LazyLogging
     srcs = ["Main.scala"],
     deps = [
         # com.typesafe.scalalogging.LazyLogging (direct from Main.scala)

--- a/language/scala/testdata/maven_direct_deps/BUILD.out
+++ b/language/scala/testdata/maven_direct_deps/BUILD.out
@@ -10,7 +10,7 @@ scala_library(
     # Main.scala - com.typesafe.scalalogging.LazyLogging (direct)
     ["Main.scala"],
     deps = [
-        # ✅ com.typesafe.scalalogging.LazyLogging (direct from Main.scala)
+        # com.typesafe.scalalogging.LazyLogging (direct from Main.scala)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )

--- a/language/scala/testdata/maven_direct_deps/BUILD.out
+++ b/language/scala/testdata/maven_direct_deps/BUILD.out
@@ -6,8 +6,9 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "app",
-    # Main.scala - com.typesafe.scalalogging.LazyLogging
-    srcs = ["Main.scala"],
+    srcs =
+    # Main.scala - com.typesafe.scalalogging.LazyLogging (direct)
+    ["Main.scala"],
     deps = [
         # com.typesafe.scalalogging.LazyLogging (direct from Main.scala)
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",


### PR DESCRIPTION
This directive will add a comment to srcs with all the known direct imports for each file.  Also renames `scala_explain_dependencies` to `scala_explain_deps`.