### PR TITLE
Change importSegmenter semantics

### DIFF
--- a/language/scala/testdata/java_provider/BUILD.out
+++ b/language/scala/testdata/java_provider/BUILD.out
@@ -5,6 +5,7 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary")
 
 scala_binary(
     name = "app",
+    # ✅ a.b.c.Main<OBJECT> //:app<scala_binary> (RESOLVED_NAME of Main.scala via "Main")
     # ✅ java.util.Map<INTERFACE> NO-LABEL<java> (DIRECT of Main.scala)
     srcs = ["Main.scala"],
 )

--- a/language/scala/testdata/override_provider/BUILD.out
+++ b/language/scala/testdata/override_provider/BUILD.out
@@ -8,6 +8,7 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "app",
+    # ✅ a.b.c.Main<OBJECT> //:app<scala_library> (RESOLVED_NAME of Main.scala via "Main")
     # ✅ com.typesafe.scalalogging.LazyLogging<OVERRIDE> @maven//:com_typesafe_scala_logging_scala_logging_2_12<override> (DIRECT of Main.scala)
     # ✅ org.slf4j.Logger<OVERRIDE> @maven//:org_slf4j_slf4j_api<override> (IMPLICIT via "com.typesafe.scalalogging.LazyLogging")
     srcs = ["Main.scala"],

--- a/language/scala/testdata/protobuf_provider/BUILD.out
+++ b/language/scala/testdata/protobuf_provider/BUILD.out
@@ -14,6 +14,7 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "app",
+    # ✅ a.b.c.Main<OBJECT> //:app<scala_library> (RESOLVED_NAME of Main.scala via "Main")
     # ❌ not.Exists<ERROR> import not found (DIRECT of Main.scala)
     # ✅ proto.Customer<PROTO_MESSAGE> //proto:proto_proto_scala_library<protobuf> (DIRECT of Main.scala)
     srcs = ["Main.scala"],

--- a/language/scala/testdata/source_provider/src/BUILD.out
+++ b/language/scala/testdata/source_provider/src/BUILD.out
@@ -2,6 +2,7 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library", 
 
 scala_library(
     name = "lib",
+    # ✅ a.b.c.Lib<OBJECT> //src:lib<scala_library> (RESOLVED_NAME of Lib.scala via "Lib")
     srcs = ["a/b/c/Lib.scala"],
 )
 

--- a/pkg/resolver/trie_scope.go
+++ b/pkg/resolver/trie_scope.go
@@ -113,5 +113,5 @@ func importSegmenter(path string, start int) (segment string, next int) {
 	if end == -1 {
 		return path[start:], -1
 	}
-	return path[start : start+end+1], start + end + 1
+	return path[start : start+end+1], start + end + 2
 }

--- a/pkg/resolver/trie_scope_test.go
+++ b/pkg/resolver/trie_scope_test.go
@@ -1,4 +1,4 @@
-package resolver_test
+package resolver
 
 import (
 	"testing"
@@ -7,11 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	sppb "github.com/stackb/scala-gazelle/build/stack/gazelle/scala/parse"
-	"github.com/stackb/scala-gazelle/pkg/resolver"
 )
 
-func makeSymbol(typ sppb.ImportType, name string, from label.Label) *resolver.Symbol {
-	return &resolver.Symbol{
+func makeSymbol(typ sppb.ImportType, name string, from label.Label) *Symbol {
+	return &Symbol{
 		Type:     typ,
 		Name:     name,
 		Label:    label.NoLabel,
@@ -22,9 +21,9 @@ func makeSymbol(typ sppb.ImportType, name string, from label.Label) *resolver.Sy
 func TestTrieScope(t *testing.T) {
 
 	for name, tc := range map[string]struct {
-		symbols []*resolver.Symbol
+		symbols []*Symbol
 		name    string
-		want    *resolver.Symbol
+		want    *Symbol
 	}{
 		"degenerate": {},
 		"miss": {
@@ -32,28 +31,28 @@ func TestTrieScope(t *testing.T) {
 			want: nil,
 		},
 		"direct hit": {
-			symbols: []*resolver.Symbol{
+			symbols: []*Symbol{
 				makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 			},
 			name: "com.foo.Bar",
 			want: makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 		},
 		"parent class hit": {
-			symbols: []*resolver.Symbol{
+			symbols: []*Symbol{
 				makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 			},
 			name: "com.foo.Bar.method",
 			want: makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 		},
 		"parent package hit": {
-			symbols: []*resolver.Symbol{
+			symbols: []*Symbol{
 				makeSymbol(sppb.ImportType_PACKAGE, "com.foo", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 			},
 			name: "com.foo.Bar",
 			want: makeSymbol(sppb.ImportType_PACKAGE, "com.foo", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 		},
 		"parent package miss": {
-			symbols: []*resolver.Symbol{
+			symbols: []*Symbol{
 				makeSymbol(sppb.ImportType_PACKAGE, "com.foo", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 			},
 			name: "com.bar.Baz",
@@ -61,7 +60,7 @@ func TestTrieScope(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			scope := resolver.NewTrieScope()
+			scope := NewTrieScope()
 			for _, known := range tc.symbols {
 				if err := scope.PutSymbol(known); err != nil {
 					t.Fatal(err)
@@ -77,9 +76,9 @@ func TestTrieScope(t *testing.T) {
 
 func TestTrieScopeGetSymbols(t *testing.T) {
 	for name, tc := range map[string]struct {
-		symbols []*resolver.Symbol
+		symbols []*Symbol
 		prefix  string
-		want    []*resolver.Symbol
+		want    []*Symbol
 	}{
 		"degenerate": {},
 		"miss": {
@@ -87,26 +86,151 @@ func TestTrieScopeGetSymbols(t *testing.T) {
 			want:   nil,
 		},
 		"completes known sorted": {
-			symbols: []*resolver.Symbol{
+			symbols: []*Symbol{
 				makeSymbol(sppb.ImportType_CLASS, "com.foo.Foo", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 				makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 				makeSymbol(sppb.ImportType_CLASS, "a.b.C", label.Label{Pkg: "a/b", Name: "scala_lib"}),
 			},
 			prefix: "com.foo",
-			want: []*resolver.Symbol{
+			want: []*Symbol{
 				makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 				makeSymbol(sppb.ImportType_CLASS, "com.foo.Foo", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			scope := resolver.NewTrieScope()
+			scope := NewTrieScope()
 			for _, known := range tc.symbols {
 				if err := scope.PutSymbol(known); err != nil {
 					t.Fatal(err)
 				}
 			}
 			got := scope.GetSymbols(tc.prefix)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTrieScopeGetScope(t *testing.T) {
+	for name, tc := range map[string]struct {
+		symbols []*Symbol
+		prefix  string
+		names   []string
+		want    []*Symbol
+	}{
+		"degenerate": {},
+		"completes known sorted": {
+			symbols: []*Symbol{
+				makeSymbol(sppb.ImportType_CLASS, "com.foo.Foo", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
+				makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
+			},
+			prefix: "com.foo",
+			names:  []string{"Foo", "Bar", "Nope"},
+			want: []*Symbol{
+				makeSymbol(sppb.ImportType_CLASS, "com.foo.Foo", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
+				makeSymbol(sppb.ImportType_CLASS, "com.foo.Bar", label.Label{Pkg: "com/foo", Name: "scala_lib"}),
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var scope Scope
+			scope = NewTrieScope()
+			for _, known := range tc.symbols {
+				if err := scope.PutSymbol(known); err != nil {
+					t.Fatal(err)
+				}
+			}
+			scope, _ = scope.GetScope(tc.prefix)
+			var got []*Symbol
+			for _, name := range tc.names {
+				if symbol, ok := scope.GetSymbol(name); ok {
+					got = append(got, symbol)
+				} else {
+					t.Log("name not found:", name)
+				}
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type result struct {
+	Segment string
+	Path    int
+}
+
+func TestImportSegmenter(t *testing.T) {
+	for name, tc := range map[string]struct {
+		want []result
+	}{
+		"degenerate": {
+			want: []result{
+				{Segment: "degenerate", Path: -1},
+			},
+		},
+		"a": {
+			want: []result{
+				{Segment: "a", Path: -1},
+			},
+		},
+		"aaa": {
+			want: []result{
+				{Segment: "aaa", Path: -1},
+			},
+		},
+		"a.b.c": {
+			want: []result{
+				{Segment: "a", Path: 2},
+				{Segment: "b", Path: 4},
+				{Segment: "c", Path: -1},
+			},
+		},
+		"a..b": {
+			want: []result{
+				{Segment: "a", Path: 2},
+				{Segment: ".b", Path: -1},
+			},
+		},
+		"a.": {
+			want: []result{
+				{Segment: "a", Path: 2},
+			},
+		},
+		"a..": {
+			want: []result{
+				{Segment: "a", Path: 2},
+				{Segment: ".", Path: -1},
+			},
+		},
+		"a...b": {
+			want: []result{
+				{Segment: "a", Path: 2},
+				{Segment: ".", Path: 4},
+				{Segment: "b", Path: -1},
+			},
+		},
+		"✅.❌": {
+			want: []result{
+				{Segment: "✅", Path: 4},
+				{Segment: "❌", Path: -1},
+			},
+		},
+		"✅✅✅.❌❌❌": {
+			want: []result{
+				{Segment: "✅✅✅", Path: 10},
+				{Segment: "❌❌❌", Path: -1},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var got []result
+			for part, i := importSegmenter(name, 0); part != ""; part, i = importSegmenter(name, i) {
+				got = append(got, result{part, i})
+			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("(-want +got):\n%s", diff)
 			}

--- a/pkg/resolver/trie_scope_test.go
+++ b/pkg/resolver/trie_scope_test.go
@@ -148,7 +148,7 @@ func TestTrieScopeGetScope(t *testing.T) {
 				if symbol, ok := scope.GetSymbol(name); ok {
 					got = append(got, symbol)
 				} else {
-					t.Log("name not found:", name)
+					t.Log("scope not found:", name)
 				}
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {


### PR DESCRIPTION
Previously, the segmenter implementation would cut a string  like `a.b.c` into `a`, `.b`, `.c`.  Now, it splits like `a`, `b`, `c`, creating more natural subscoping.