### PR TITLE
Revert "Populate import symbols with correct name when Importee.Rename"

### DIFF
--- a/language/scala/scala_rule.go
+++ b/language/scala/scala_rule.go
@@ -329,7 +329,8 @@ func (r *scalaRule) fileImports(file *sppb.File, imports resolver.ImportMap) {
 			log.Fatalf("invalid extends token: %q: should have form '(class|interface|object) com.foo.Bar' ", token)
 		}
 
-		name := parts[1] // note: parts[0] is the 'kind'
+		// kind := parts[0]
+		name := parts[1]
 
 		// assume the name if fully-qualified, so resolve it from the "root"
 		// scope rather than involving package scopes.

--- a/pkg/parser/scalameta_parser.mjs
+++ b/pkg/parser/scalameta_parser.mjs
@@ -443,7 +443,7 @@ class ScalaFile {
                     scope.addImport([ref, importee.name.value].join('.'), importee.name.value)
                     break;
                 case 'Importee.Rename':
-                    scope.addImport([ref, importee.rename.value].join('.'), importee.rename.value)
+                    scope.addImport([ref, importee.name.value].join('.'), importee.name.value)
                     break;
                 case 'Importee.Unimport':
                     // an unimport is specifically excluded from the scala

--- a/pkg/parser/scalameta_parser_test.go
+++ b/pkg/parser/scalameta_parser_test.go
@@ -175,7 +175,7 @@ object Palette {
 						Objects:  []string{"color.Palette"},
 						Imports: []string{
 							"java.awt.Color",
-							"scala.util.Random.rint",
+							"scala.util.Random.nextInt",
 						},
 						Names: []string{
 							"MandelPalette",


### PR DESCRIPTION
Reverts stackb/scala-gazelle#103.

This change was intended to improve the resolution of free symbols in a scala file, but it had an unintended side effect that the renamed fully-qualified import was populated into the import list.
