### PR TITLE
Add rule coverage

### DIFF
--- a/language/scala/BUILD.bazel
+++ b/language/scala/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "cache.go",
         "configure.go",
         "conflict_resolver_registry.go",
+        "coverage.go",
         "cross_resolve.go",
         "deps_cleaner_registry.go",
         "existing_scala_rule.go",
@@ -79,6 +80,7 @@ gazelle_binary(
 go_test(
     name = "scala_test",
     srcs = [
+        "coverage_test.go",
         "existing_scala_rule_test.go",
         "flags_test.go",
         "golden_test.go",

--- a/language/scala/coverage.go
+++ b/language/scala/coverage.go
@@ -16,11 +16,9 @@ func (sl *scalaLang) reportCoverage(printf func(format string, v ...any)) {
 
 	var managed int
 	var total int
-
 	for _, pkg := range sl.packages {
-		coverage := pkg.ruleCoverage()
-		managed += coverage.managed
-		total += coverage.total
+		managed += pkg.ruleCoverage.managed
+		total += pkg.ruleCoverage.total
 	}
 
 	percent := float32(managed) / float32(total) * 100

--- a/language/scala/coverage.go
+++ b/language/scala/coverage.go
@@ -1,0 +1,29 @@
+package scala
+
+type packageRuleCoverage struct {
+	// managed represents the total number of rules that are managed by
+	// scala-gazelle (actual number of rules that we provided deps for)
+	managed int
+	// total represents the total number of rules in a package that we have a
+	// RuleProvider for.
+	total int
+}
+
+func (sl *scalaLang) reportCoverage(printf func(format string, v ...any)) {
+	if !sl.reportCoverageFlagValue {
+		return
+	}
+
+	var managed int
+	var total int
+
+	for _, pkg := range sl.packages {
+		coverage := pkg.ruleCoverage()
+		managed += coverage.managed
+		total += coverage.total
+	}
+
+	percent := float32(managed) / float32(total) * 100
+
+	printf("scala-gazelle coverage is %0.1f%% (%d/%d)", percent, managed, total)
+}

--- a/language/scala/coverage.go
+++ b/language/scala/coverage.go
@@ -10,7 +10,7 @@ type packageRuleCoverage struct {
 }
 
 func (sl *scalaLang) reportCoverage(printf func(format string, v ...any)) {
-	if !sl.reportCoverageFlagValue {
+	if !sl.existingScalaRuleCoverageFlagValue {
 		return
 	}
 

--- a/language/scala/coverage_test.go
+++ b/language/scala/coverage_test.go
@@ -1,0 +1,1 @@
+package scala

--- a/language/scala/flags.go
+++ b/language/scala/flags.go
@@ -29,12 +29,14 @@ const (
 	scalaGazellePrintCacheKeyFlagName    = "scala_gazelle_print_cache_key"
 	cpuprofileFileFlagName               = "cpuprofile_file"
 	memprofileFileFlagName               = "memprofile_file"
+	coverageFlagName                     = "coverage"
 )
 
 // RegisterFlags implements part of the language.Language interface
 func (sl *scalaLang) RegisterFlags(flags *flag.FlagSet, cmd string, c *config.Config) {
 	flags.BoolVar(&sl.debugProcessFlagValue, scalaGazelleDebugProcessFileFlagName, false, "if true, prints the process ID and waits for debugger to attach")
 	flags.BoolVar(&sl.printCacheKey, scalaGazellePrintCacheKeyFlagName, true, "if a cache key is set, print the version for auditing purposes")
+	flags.BoolVar(&sl.reportCoverageFlagValue, coverageFlagName, true, "report coverage statistics")
 	flags.StringVar(&sl.cacheFileFlagValue, scalaGazelleCacheFileFlagName, "", "optional path a cache file (.json or .pb)")
 	flags.StringVar(&sl.cacheKeyFlagValue, scalaGazelleCacheKeyFlagName, "", "optional string that can be used to bust the cache file")
 	flags.StringVar(&sl.cpuprofileFlagValue, cpuprofileFileFlagName, "", "optional path a cpuprofile file (.prof)")

--- a/language/scala/flags.go
+++ b/language/scala/flags.go
@@ -23,20 +23,20 @@ const (
 	existingScalaBinaryRuleFlagName      = "existing_scala_binary_rule"
 	existingScalaLibraryRuleFlagName     = "existing_scala_library_rule"
 	existingScalaTestRuleFlagName        = "existing_scala_test_rule"
+	existingScalaRuleCoverageFlagName    = "existing_scala_rule_coverage"
 	scalaGazelleCacheFileFlagName        = "scala_gazelle_cache_file"
 	scalaGazelleDebugProcessFileFlagName = "scala_gazelle_debug_process"
 	scalaGazelleCacheKeyFlagName         = "scala_gazelle_cache_key"
 	scalaGazellePrintCacheKeyFlagName    = "scala_gazelle_print_cache_key"
 	cpuprofileFileFlagName               = "cpuprofile_file"
 	memprofileFileFlagName               = "memprofile_file"
-	coverageFlagName                     = "coverage"
 )
 
 // RegisterFlags implements part of the language.Language interface
 func (sl *scalaLang) RegisterFlags(flags *flag.FlagSet, cmd string, c *config.Config) {
 	flags.BoolVar(&sl.debugProcessFlagValue, scalaGazelleDebugProcessFileFlagName, false, "if true, prints the process ID and waits for debugger to attach")
 	flags.BoolVar(&sl.printCacheKey, scalaGazellePrintCacheKeyFlagName, true, "if a cache key is set, print the version for auditing purposes")
-	flags.BoolVar(&sl.reportCoverageFlagValue, coverageFlagName, true, "report coverage statistics")
+	flags.BoolVar(&sl.existingScalaRuleCoverageFlagValue, existingScalaRuleCoverageFlagName, true, "report coverage statistics")
 	flags.StringVar(&sl.cacheFileFlagValue, scalaGazelleCacheFileFlagName, "", "optional path a cache file (.json or .pb)")
 	flags.StringVar(&sl.cacheKeyFlagValue, scalaGazelleCacheKeyFlagName, "", "optional string that can be used to bust the cache file")
 	flags.StringVar(&sl.cpuprofileFlagValue, cpuprofileFileFlagName, "", "optional path a cpuprofile file (.prof)")

--- a/language/scala/language.go
+++ b/language/scala/language.go
@@ -50,10 +50,10 @@ type scalaLang struct {
 	existingScalaLibraryRulesFlagValue collections.StringSlice
 	// existingScalaLibraryRulesFlagValue is the value of the
 	// existing_scala_test_rule repeatable flag
-	existingScalaTestRulesFlagValue collections.StringSlice
-	cpuprofileFlagValue             string
-	reportCoverageFlagValue         bool
-	memprofileFlagValue             string
+	existingScalaTestRulesFlagValue    collections.StringSlice
+	cpuprofileFlagValue                string
+	existingScalaRuleCoverageFlagValue bool
+	memprofileFlagValue                string
 	// cache is the loaded cache, if configured
 	cache scpb.Cache
 	// ruleProviderRegistry is the rule registry implementation.  This holds the

--- a/language/scala/language.go
+++ b/language/scala/language.go
@@ -52,6 +52,7 @@ type scalaLang struct {
 	// existing_scala_test_rule repeatable flag
 	existingScalaTestRulesFlagValue collections.StringSlice
 	cpuprofileFlagValue             string
+	reportCoverageFlagValue         bool
 	memprofileFlagValue             string
 	// cache is the loaded cache, if configured
 	cache scpb.Cache

--- a/language/scala/lifecycle.go
+++ b/language/scala/lifecycle.go
@@ -37,6 +37,7 @@ func (sl *scalaLang) onEnd() {
 		}
 	}
 
+	sl.reportCoverage(log.Printf)
 	sl.stopCpuProfiling()
 	sl.stopMemoryProfiling()
 }

--- a/language/scala/scala_package.go
+++ b/language/scala/scala_package.go
@@ -46,7 +46,7 @@ type scalaPackage struct {
 	// all rules in a package have been processed.
 	resolveWork []func()
 	// used for tracking coverage
-	packageRuleCoverage *packageRuleCoverage
+	ruleCoverage *packageRuleCoverage
 }
 
 // newScalaPackage constructs a Package given a list of scala files.
@@ -58,15 +58,15 @@ func newScalaPackage(
 	parser parser.Parser,
 	universe resolver.Universe) *scalaPackage {
 	s := &scalaPackage{
-		rel:                 rel,
-		parser:              parser,
-		universe:            universe,
-		providerRegistry:    providerRegistry,
-		file:                file,
-		cfg:                 cfg,
-		rules:               make(map[string]*rule.Rule),
-		resolveWork:         make([]func(), 0),
-		packageRuleCoverage: &packageRuleCoverage{},
+		rel:              rel,
+		parser:           parser,
+		universe:         universe,
+		providerRegistry: providerRegistry,
+		file:             file,
+		cfg:              cfg,
+		rules:            make(map[string]*rule.Rule),
+		resolveWork:      make([]func(), 0),
+		ruleCoverage:     &packageRuleCoverage{},
 	}
 	s.gen = s.generateRules(true)
 	// s.empty = s.generateRules(false)
@@ -131,7 +131,7 @@ func (s *scalaPackage) generateRules(enabled bool) []scalarule.RuleProvider {
 			fqn := fullyQualifiedLoadName(s.file.Loads, r.Kind())
 			existingRulesByFQN[fqn] = append(existingRulesByFQN[fqn], r)
 			if _, ok := s.providerRegistry.LookupProvider(fqn); ok {
-				s.packageRuleCoverage.total += 1
+				s.ruleCoverage.total += 1
 			}
 		}
 	}
@@ -153,7 +153,7 @@ func (s *scalaPackage) generateRules(enabled bool) []scalarule.RuleProvider {
 			for _, r := range existing {
 				rule := s.resolveRule(ruleConfig, r)
 				if rule != nil {
-					s.packageRuleCoverage.managed += 1
+					s.ruleCoverage.managed += 1
 					rules = append(rules, rule)
 				}
 			}
@@ -267,8 +267,4 @@ func (s *scalaPackage) getProvidedRules(providers []scalarule.RuleProvider, shou
 		rules = append(rules, r)
 	}
 	return rules
-}
-
-func (s *scalaPackage) ruleCoverage() *packageRuleCoverage {
-	return s.packageRuleCoverage
 }

--- a/pkg/scalaconfig/config.go
+++ b/pkg/scalaconfig/config.go
@@ -406,7 +406,6 @@ func (c *Config) GetImplicitImports(lang, imp string) (deps []string) {
 
 // ConfiguredRules returns an ordered list of configured rules
 func (c *Config) ConfiguredRules() []*scalarule.Config {
-
 	names := make([]string, 0)
 	for name := range c.rules {
 		names = append(names, name)


### PR DESCRIPTION
When coverage is enabled (by default `true`, can be disabled by `--existing_scala_rule_coverage=false`), scala-gazelle will report coverage statistics on the percent of possible existing rules that could be provided and the actual number that could be managed:

```
gazelle: scala-gazelle coverage is 33.6% (606/1804)
```