### PR TITLE
source provider: ensure all parsed filenames are workspace-relative

### DIFF
--- a/language/scala/diff_test.go
+++ b/language/scala/diff_test.go
@@ -34,7 +34,6 @@ func (tc *testCase) Run(name string, t *testing.T) {
 		env := append(tc.env,
 			"SCALA_GAZELLE_SHOW_PROGRESS=0",
 			"SCALA_GAZELLE_SHOW_COVERAGE=0",
-			fmt.Sprintf("SCALA_GAZELLE_LOG_FILE=%s/scala-gazelle.log", dir),
 		)
 		if !tc.skipCleanup {
 			defer cleanup()

--- a/language/scala/language.go
+++ b/language/scala/language.go
@@ -1,6 +1,7 @@
 package scala
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -165,10 +166,6 @@ func getLoggerFilename() string {
 	if name, ok := procutil.LookupEnv(SCALA_GAZELLE_LOG_FILE); ok && len(name) > 0 {
 		return name
 	}
-	if tmpdir, ok := procutil.LookupEnv(TEST_TMPDIR); ok && procutil.DirExists(tmpdir) {
-		return filepath.Join(tmpdir, "scala-gazelle.log")
-	}
-
 	return ""
 }
 
@@ -183,6 +180,11 @@ func setupLogger() (*os.File, zerolog.Logger) {
 	if err != nil {
 		panic("cannot open log file: " + err.Error())
 	}
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		panic("cannot get absolute path of log file: " + err.Error())
+	}
+	fmt.Fprintf(os.Stdout, "gazelle: writing scala-gazelle log to: %s\n", abs)
 
 	logger := zerolog.New(file).With().Caller().Logger()
 

--- a/language/scala/scala_package.go
+++ b/language/scala/scala_package.go
@@ -234,11 +234,12 @@ func (s *scalaPackage) GeneratedRules() (rules []*rule.Rule) {
 // ParseRule implements part of the scalarule.Package interface.
 func (s *scalaPackage) ParseRule(r *rule.Rule, attrName string) (scalaRule scalarule.Rule, err error) {
 	dir := filepath.Join(s.repoRootDir(), s.args.Rel)
+
+	// collect and filter .scala files from the `srcs` attribute.
 	srcs, err := glob.CollectFilenames(s.args.File, dir, r.Attr(attrName))
 	if err != nil {
 		return nil, err
 	}
-
 	scalaSrcs := make([]string, 0, len(srcs))
 	for _, src := range srcs {
 		if !strings.HasSuffix(src, ".scala") {

--- a/pkg/provider/testdata/DockerKit.scala.golden.json
+++ b/pkg/provider/testdata/DockerKit.scala.golden.json
@@ -3,7 +3,7 @@
   "kind": "scala_library",
   "files": [
     {
-      "filename": "testdata/DockerKit.scala",
+      "filename": "pkg/provider/testdata/DockerKit.scala",
       "imports": [
         "com.github.dockerjava.api.DockerClient",
         "com.github.dockerjava.api.async.ResultCallback",

--- a/pkg/provider/testdata/FullyQualified.scala.golden.json
+++ b/pkg/provider/testdata/FullyQualified.scala.golden.json
@@ -3,7 +3,7 @@
   "kind": "scala_library",
   "files": [
     {
-      "filename": "testdata/FullyQualified.scala",
+      "filename": "pkg/provider/testdata/FullyQualified.scala",
       "imports": [
         "sk.ygor.stackoverflow.q53326545.macros.ExampleMacro.methodName"
       ],

--- a/pkg/provider/testdata/GreeterClient.scala.golden.json
+++ b/pkg/provider/testdata/GreeterClient.scala.golden.json
@@ -3,7 +3,7 @@
   "kind": "scala_library",
   "files": [
     {
-      "filename": "testdata/GreeterClient.scala",
+      "filename": "pkg/provider/testdata/GreeterClient.scala",
       "imports": [
         "akka.Done",
         "akka.NotUsed",

--- a/pkg/provider/testdata/PostgresAccess.scala.golden.json
+++ b/pkg/provider/testdata/PostgresAccess.scala.golden.json
@@ -3,7 +3,7 @@
   "kind": "scala_library",
   "files": [
     {
-      "filename": "testdata/PostgresAccess.scala",
+      "filename": "pkg/provider/testdata/PostgresAccess.scala",
       "packages": [
         "auth.dao"
       ],

--- a/pkg/provider/testdata/UserId.scala.golden.json
+++ b/pkg/provider/testdata/UserId.scala.golden.json
@@ -3,7 +3,7 @@
   "kind": "scala_library",
   "files": [
     {
-      "filename": "testdata/UserId.scala",
+      "filename": "pkg/provider/testdata/UserId.scala",
       "packages": [
         "common.types"
       ],


### PR DESCRIPTION
Parsed scala files that arrive in the `scala_fileset` (pre-parsed) have filenames that are workspace-relative.  Previously, files parsed at runtime internally kept a package-relative path.  This affected sorting of filesnames for the later resolve phase.  This PR normalizes it such that all filenames are workspace-relative.
