### PR TITLE
Refactor scala_fileset

### DIFF
--- a/language/files/files.go
+++ b/language/files/files.go
@@ -102,7 +102,7 @@ func (pl *FilesLanguage) Resolve(
 	ix *resolve.RuleIndex,
 	rc *repo.RemoteCache,
 	r *rule.Rule,
-	importsRaw interface{},
+	importsRaw any,
 	from label.Label,
 ) {
 }

--- a/language/scala/existing_scala_rule.go
+++ b/language/scala/existing_scala_rule.go
@@ -82,18 +82,12 @@ func (s *existingScalaRuleProvider) ResolveRule(cfg *scalarule.Config, pkg scala
 			log.Printf("skipping %s %s: unable to collect srcs: %v", r.Kind(), r.Name(), err)
 			return nil
 		}
-		// rule has no srcs.  This is OK for binary rules, sometimes they only
-		// have a main_class.
-		// if !s.isBinary {
-		// 	return nil // no need to print a warning
-		// }
 	}
 	if scalaRule == nil {
 		log.Panicln("scalaRule should not be nil!")
 	}
 
 	r.SetPrivateAttr(config.GazelleImportsKey, scalaRule)
-	r.SetPrivateAttr("_scala_files", scalaRule.Files())
 
 	return &existingScalaRule{cfg, pkg, r, scalaRule, s.isBinary, s.isLibrary, s.isTest}
 }

--- a/language/scala/scala_package.go
+++ b/language/scala/scala_package.go
@@ -51,6 +51,8 @@ type scalaPackage struct {
 	resolveWork []func()
 	// used for tracking coverage
 	ruleCoverage *packageRuleCoverage
+	// files is a list of scala files that are within this package.
+	files []*sppb.File
 }
 
 // newScalaPackage constructs a Package given a list of scala files.
@@ -276,13 +278,18 @@ func (s *scalaPackage) ParseRule(r *rule.Rule, attrName string) (scalaRule scala
 	}
 
 	scalaRule = newScalaRule(logger, ctx, rule)
-
+	s.files = append(s.files, scalaRule.Files()...)
 	return
 }
 
 // repoRootDir return the root directory of the repo.
 func (s *scalaPackage) repoRootDir() string {
 	return s.cfg.Config().RepoRoot
+}
+
+// Files implements part of the scalarule.Package interface.
+func (r *scalaPackage) Files() []*sppb.File {
+	return r.files
 }
 
 // Rules provides the aggregated rule list for the package.

--- a/pkg/scalafiles/BUILD.bazel
+++ b/pkg/scalafiles/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/collections",
         "//pkg/scalarule",
         "@bazel_gazelle//config:go_default_library",
+        "@bazel_gazelle//label:go_default_library",
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
     ],

--- a/pkg/scalafiles/scala_files.go
+++ b/pkg/scalafiles/scala_files.go
@@ -72,6 +72,16 @@ func (s *ScalaFilesRuleProvider) ProvideRule(cfg *scalarule.Config, pkg scalarul
 	r.SetAttr("visibility", []string{"//visibility:public"})
 	r.SetPrivateAttr(config.GazelleImportsKey, []string{})
 
+	var srcs []string
+	for _, file := range pkg.GenerateArgs().RegularFiles {
+		if strings.HasSuffix(file, ".scala") {
+			srcs = append(srcs, file)
+		}
+	}
+	if len(srcs) > 0 {
+		r.SetAttr("srcs", srcs)
+	}
+
 	return &scalaFilesRule{cfg, pkg, r}
 }
 

--- a/pkg/scalarule/package.go
+++ b/pkg/scalarule/package.go
@@ -3,6 +3,7 @@ package scalarule
 import (
 	"github.com/bazelbuild/bazel-gazelle/language"
 	grule "github.com/bazelbuild/bazel-gazelle/rule"
+	sppb "github.com/stackb/scala-gazelle/build/stack/gazelle/scala/parse"
 )
 
 // Package is responsible for instantiating a Rule interface for the given
@@ -15,4 +16,7 @@ type Package interface {
 	GenerateArgs() language.GenerateArgs
 	// GeneratedRules returns a list of generated rules in the package.
 	GeneratedRules() []*grule.Rule
+	// Files returns the list of files in the package.  Only valid once all
+	// rules have been parsed/processed.
+	Files() []*sppb.File
 }


### PR DESCRIPTION
Refactor the `scala_files` and `scala_fileset` rules.  

- Change `scala_package` to track it's own set of scala files rather than trying to discover it later.
- Simplify logic
- Make `scala_fileset` a resolvable rule rather than a generated one.
