### PR TITLE
Add maven lockfile v2 support and fix bzlmod label handling

### DIFF
--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -19,7 +19,7 @@ var (
 	nonWordRe    = regexp.MustCompile(`\W+`)
 )
 
-func CleanupLabel(in string) string {
+func CleanupLabelName(in string) string {
 	return nonWordRe.ReplaceAllString(in, "_")
 }
 

--- a/pkg/maven/config.go
+++ b/pkg/maven/config.go
@@ -41,3 +41,38 @@ type Dep struct {
 	URL                string   `json:"url,omitempty"`
 	Exclusions         []string `json:"exclusions,omitempty"`
 }
+
+// LockfileV2 represents the maven2_install.json structure
+type LockfileV2 struct {
+	InputArtifactsHash    int64                          `json:"__INPUT_ARTIFACTS_HASH"`
+	ResolvedArtifactsHash int64                          `json:"__RESOLVED_ARTIFACTS_HASH"`
+	Version               string                         `json:"version"`
+	Artifacts             map[string]ArtifactV2          `json:"artifacts"`
+	Dependencies          map[string][]string            `json:"dependencies"`
+	Packages              map[string][]string            `json:"packages"`
+	Repositories          map[string][]string            `json:"repositories"`
+	Services              map[string]map[string][]string `json:"services"`
+	ConflictResolution    map[string]string              `json:"conflict_resolution"`
+	Skipped               []string                       `json:"skipped"`
+}
+
+// ArtifactV2 represents metadata for a single maven artifact
+type ArtifactV2 struct {
+	Version string            `json:"version"`
+	Shasums map[string]string `json:"shasums"`
+}
+
+func loadLockfileV2(filename string) (*LockfileV2, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var lf LockfileV2
+	if err := json.NewDecoder(f).Decode(&lf); err != nil {
+		return nil, err
+	}
+
+	return &lf, nil
+}

--- a/pkg/maven/resolver.go
+++ b/pkg/maven/resolver.go
@@ -59,7 +59,7 @@ func NewResolver(installFile, mavenWorkspaceName, lang string, warn warnFunc, pu
 
 func newResolverFromV1(r *mavenResolver, c *configFile, mavenWorkspaceName string, putSymbol putSymbolFunc) (Resolver, error) {
 	for _, dep := range c.DependencyTree.Dependencies {
-		log.Println("loaded dep:", dep.Coord)
+		log.Println("loading v1 dep:", dep.Coord)
 		coord, err := ParseCoordinate(dep.Coord)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse coordinate %v: %w", dep.Coord, err)

--- a/pkg/maven/resolver.go
+++ b/pkg/maven/resolver.go
@@ -3,6 +3,8 @@ package maven
 import (
 	"errors"
 	"fmt"
+	"log"
+	"sort"
 
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/stackb/scala-gazelle/pkg/bazel"
@@ -38,17 +40,31 @@ func NewResolver(installFile, mavenWorkspaceName, lang string, warn warnFunc, pu
 		artifacts: make(map[string]label.Label),
 	}
 
+	log.Println("loading configuration from:", installFile)
+
+	// Try v2 format first
+	v2, err := loadLockfileV2(installFile)
+	if err == nil && v2.Version == "2" {
+		return newResolverFromV2(&r, v2, mavenWorkspaceName, putSymbol)
+	}
+
+	// Fallback to v1 format
 	c, err := loadConfiguration(installFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading configuration %s: %w", installFile, err)
 	}
 
+	return newResolverFromV1(&r, c, mavenWorkspaceName, putSymbol)
+}
+
+func newResolverFromV1(r *mavenResolver, c *configFile, mavenWorkspaceName string, putSymbol putSymbolFunc) (Resolver, error) {
 	for _, dep := range c.DependencyTree.Dependencies {
-		c, err := ParseCoordinate(dep.Coord)
+		log.Println("loaded dep:", dep.Coord)
+		coord, err := ParseCoordinate(dep.Coord)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse coordinate %v: %w", dep.Coord, err)
 		}
-		from := label.Label{Repo: mavenWorkspaceName, Name: bazel.CleanupLabel(c.ArtifactString())}
+		from := label.Label{Repo: mavenWorkspaceName, Name: bazel.CleanupLabelName(coord.ArtifactString())}
 		labelString := from.String()
 		r.artifacts[dep.Coord] = from
 
@@ -58,7 +74,30 @@ func NewResolver(installFile, mavenWorkspaceName, lang string, warn warnFunc, pu
 		}
 	}
 
-	return &r, nil
+	return r, nil
+}
+
+func newResolverFromV2(r *mavenResolver, lf *LockfileV2, mavenWorkspaceName string, putSymbol putSymbolFunc) (Resolver, error) {
+	// Sort artifact IDs for deterministic iteration
+	ids := make([]string, 0, len(lf.Packages))
+	for id := range lf.Packages {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		packages := lf.Packages[id]
+		from := label.Label{Repo: mavenWorkspaceName, Name: bazel.CleanupLabelName(id)}
+		labelString := from.String()
+		r.artifacts[id] = from
+
+		for _, pkg := range packages {
+			r.data.Add(pkg, labelString)
+			putSymbol(resolver.NewSymbol(sppb.ImportType_PACKAGE, pkg, mavenWorkspaceName, from))
+		}
+	}
+
+	return r, nil
 }
 
 func (r *mavenResolver) Name() string {

--- a/pkg/maven/resolver.go
+++ b/pkg/maven/resolver.go
@@ -59,7 +59,6 @@ func NewResolver(installFile, mavenWorkspaceName, lang string, warn warnFunc, pu
 
 func newResolverFromV1(r *mavenResolver, c *configFile, mavenWorkspaceName string, putSymbol putSymbolFunc) (Resolver, error) {
 	for _, dep := range c.DependencyTree.Dependencies {
-		log.Println("loading v1 dep:", dep.Coord)
 		coord, err := ParseCoordinate(dep.Coord)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse coordinate %v: %w", dep.Coord, err)

--- a/pkg/maven/resolver_test.go
+++ b/pkg/maven/resolver_test.go
@@ -1,0 +1,219 @@
+package maven
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stackb/scala-gazelle/pkg/resolver"
+)
+
+func TestNewResolver(t *testing.T) {
+	for name, tc := range map[string]struct {
+		content    string
+		wantLabels []string
+	}{
+		"v1 format": {
+			content: `{
+				"dependency_tree": {
+					"dependencies": [
+						{
+							"coord": "xml-apis:xml-apis:1.4.01",
+							"dependencies": [],
+							"directDependencies": [],
+							"file": "xml-apis-1.4.01.jar",
+							"packages": ["javax.xml", "javax.xml.parsers"],
+							"sha256": "abc123"
+						}
+					],
+					"version": "0.1.0"
+				}
+			}`,
+			wantLabels: []string{
+				"@maven//:xml_apis_xml_apis",
+				"@maven//:xml_apis_xml_apis",
+			},
+		},
+		"v2 format": {
+			content: `{
+				"__INPUT_ARTIFACTS_HASH": 123,
+				"__RESOLVED_ARTIFACTS_HASH": 456,
+				"version": "2",
+				"artifacts": {
+					"xml-apis:xml-apis": {
+						"version": "1.4.01",
+						"shasums": {"jar": "abc123"}
+					}
+				},
+				"packages": {
+					"xml-apis:xml-apis": ["javax.xml", "javax.xml.parsers"]
+				},
+				"dependencies": {},
+				"repositories": {},
+				"services": {},
+				"conflict_resolution": {},
+				"skipped": []
+			}`,
+			wantLabels: []string{
+				"@maven//:xml_apis_xml_apis",
+				"@maven//:xml_apis_xml_apis",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			installFile := filepath.Join(tmpDir, "maven_install.json")
+			if err := os.WriteFile(installFile, []byte(tc.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			var gotSymbols []*resolver.Symbol
+			putSymbol := func(s *resolver.Symbol) error {
+				gotSymbols = append(gotSymbols, s)
+				return nil
+			}
+
+			r, err := NewResolver(installFile, "maven", "scala", func(format string, args ...interface{}) {}, putSymbol)
+			if err != nil {
+				t.Fatalf("NewResolver: %v", err)
+			}
+
+			if r.Name() != "maven" {
+				t.Errorf("Name() = %q, want %q", r.Name(), "maven")
+			}
+
+			var gotLabels []string
+			for _, s := range gotSymbols {
+				gotLabels = append(gotLabels, s.Label.String())
+			}
+
+			if diff := cmp.Diff(tc.wantLabels, gotLabels); diff != "" {
+				t.Errorf("labels (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNewResolverV2Deterministic(t *testing.T) {
+	// Create a v2 lockfile with multiple artifacts
+	content := `{
+		"__INPUT_ARTIFACTS_HASH": 123,
+		"__RESOLVED_ARTIFACTS_HASH": 456,
+		"version": "2",
+		"artifacts": {},
+		"packages": {
+			"com.example:charlie": ["com.example.charlie"],
+			"com.example:alpha": ["com.example.alpha"],
+			"com.example:bravo": ["com.example.bravo"]
+		},
+		"dependencies": {},
+		"repositories": {},
+		"services": {},
+		"conflict_resolution": {},
+		"skipped": []
+	}`
+
+	tmpDir := t.TempDir()
+	installFile := filepath.Join(tmpDir, "maven_install.json")
+	if err := os.WriteFile(installFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run multiple times to verify deterministic ordering
+	var firstOrder []string
+	for i := 0; i < 10; i++ {
+		var gotSymbols []*resolver.Symbol
+		putSymbol := func(s *resolver.Symbol) error {
+			gotSymbols = append(gotSymbols, s)
+			return nil
+		}
+
+		_, err := NewResolver(installFile, "maven", "scala", func(format string, args ...interface{}) {}, putSymbol)
+		if err != nil {
+			t.Fatalf("NewResolver: %v", err)
+		}
+
+		var order []string
+		for _, s := range gotSymbols {
+			order = append(order, s.Name)
+		}
+
+		if i == 0 {
+			firstOrder = order
+			// Verify alphabetical ordering
+			want := []string{"com.example.alpha", "com.example.bravo", "com.example.charlie"}
+			if diff := cmp.Diff(want, order); diff != "" {
+				t.Errorf("expected alphabetical order (-want +got):\n%s", diff)
+			}
+		} else {
+			if diff := cmp.Diff(firstOrder, order); diff != "" {
+				t.Errorf("iteration %d: order is not deterministic (-first +current):\n%s", i, diff)
+			}
+		}
+	}
+}
+
+func TestResolverResolve(t *testing.T) {
+	content := `{
+		"__INPUT_ARTIFACTS_HASH": 123,
+		"__RESOLVED_ARTIFACTS_HASH": 456,
+		"version": "2",
+		"artifacts": {},
+		"packages": {
+			"com.example:foo": ["com.example.foo", "com.example.foo.bar"]
+		},
+		"dependencies": {},
+		"repositories": {},
+		"services": {},
+		"conflict_resolution": {},
+		"skipped": []
+	}`
+
+	tmpDir := t.TempDir()
+	installFile := filepath.Join(tmpDir, "maven_install.json")
+	if err := os.WriteFile(installFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewResolver(installFile, "maven", "scala", func(format string, args ...interface{}) {}, func(s *resolver.Symbol) error { return nil })
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	for name, tc := range map[string]struct {
+		pkg       string
+		wantLabel label.Label
+		wantErr   bool
+	}{
+		"found package": {
+			pkg:       "com.example.foo",
+			wantLabel: label.Label{Repo: "maven", Name: "com_example_foo"},
+		},
+		"found nested package": {
+			pkg:       "com.example.foo.bar",
+			wantLabel: label.Label{Repo: "maven", Name: "com_example_foo"},
+		},
+		"not found": {
+			pkg:     "com.example.notfound",
+			wantErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := r.Resolve(tc.pkg)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantLabel, got); diff != "" {
+				t.Errorf("Resolve (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/provider/java_provider.go
+++ b/pkg/provider/java_provider.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
@@ -173,9 +174,14 @@ func (p *JavaProvider) readClassFile(classFile *jipb.ClassFile, from label.Label
 }
 
 func (p *JavaProvider) putSymbol(impType sppb.ImportType, imp string, from label.Label) *resolver.Symbol {
-	symbol := resolver.NewSymbol(impType, imp, p.Name(), from)
-	p.scope.PutSymbol(symbol)
-	return symbol
+	sym := resolver.NewSymbol(impType, imp, p.Name(), from)
+
+	if strings.HasPrefix(sym.Label.Repo, "rules_jvm_external") {
+		log.Panicf("maven putSymbol: %s", sym.Label.Repo)
+	}
+
+	p.scope.PutSymbol(sym)
+	return sym
 }
 
 // ParseLabelNonCanonical parses a label string and returns a non-canonical label.

--- a/pkg/provider/java_provider.go
+++ b/pkg/provider/java_provider.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
@@ -175,11 +174,6 @@ func (p *JavaProvider) readClassFile(classFile *jipb.ClassFile, from label.Label
 
 func (p *JavaProvider) putSymbol(impType sppb.ImportType, imp string, from label.Label) *resolver.Symbol {
 	sym := resolver.NewSymbol(impType, imp, p.Name(), from)
-
-	if strings.HasPrefix(sym.Label.Repo, "rules_jvm_external") {
-		log.Panicf("maven putSymbol: %s", sym.Label.Repo)
-	}
-
 	p.scope.PutSymbol(sym)
 	return sym
 }

--- a/pkg/provider/maven_provider.go
+++ b/pkg/provider/maven_provider.go
@@ -69,9 +69,18 @@ func (p *MavenProvider) loadFile(dir string, filename string, scope resolver.Sco
 	if !filepath.IsAbs(filename) {
 		filename = filepath.Join(dir, filename)
 	}
+
 	resolver, err := maven.NewResolver(filename, name, p.lang, func(format string, args ...interface{}) {
 		log.Printf(format, args...)
-	}, scope.PutSymbol)
+	}, func(sym *resolver.Symbol) error {
+		if strings.HasPrefix(sym.Label.Repo, "rules_jvm_external") {
+			log.Panicf("maven putSymbol: %s", sym.Label.Repo)
+		} else {
+			log.Printf("maven putSymbol: %s", sym.Label.Repo)
+		}
+		// log.Panicf("scope.PutSymbol %s %v", sym.Name, sym.Label)
+		return scope.PutSymbol(sym)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("initializing maven resolver: %w", err)
 	}

--- a/pkg/provider/maven_provider.go
+++ b/pkg/provider/maven_provider.go
@@ -72,15 +72,7 @@ func (p *MavenProvider) loadFile(dir string, filename string, scope resolver.Sco
 
 	resolver, err := maven.NewResolver(filename, name, p.lang, func(format string, args ...interface{}) {
 		log.Printf(format, args...)
-	}, func(sym *resolver.Symbol) error {
-		if strings.HasPrefix(sym.Label.Repo, "rules_jvm_external") {
-			log.Panicf("maven putSymbol: %s", sym.Label.Repo)
-		} else {
-			log.Printf("maven putSymbol: %s", sym.Label.Repo)
-		}
-		// log.Panicf("scope.PutSymbol %s %v", sym.Name, sym.Label)
-		return scope.PutSymbol(sym)
-	})
+	}, scope.PutSymbol)
 	if err != nil {
 		return nil, fmt.Errorf("initializing maven resolver: %w", err)
 	}

--- a/rules/java_index.bzl
+++ b/rules/java_index.bzl
@@ -2,18 +2,20 @@
 """
 
 load(":providers.bzl", "JarIndexerAspectInfo")
-load(":java_indexer_aspect.bzl", "jarindexer_action", "java_indexer_aspect")
+load(":java_indexer_aspect.bzl", "get_apparent_label", "jarindexer_action", "java_indexer_aspect")
 
 def target_label(target):
-    return str(target.label)
+    return get_apparent_label(target.label)
 
 def merge_action(ctx, output_file, jarindex_files):
     args = ctx.actions.args()
     args.use_param_file("@%s", use_always = True)
     args.add("--output_file", output_file)
-    args.add_all(ctx.attr.platform_deps, map_each = target_label, format_each = "--predefined=%s", uniquify = True)
+
+    for dep in ctx.attr.platform_deps:
+        args.add("--predefined=%s" % target_label(dep))
     for pkg, dep in ctx.attr.preferred_deps.items():
-        args.add("--preferred=%s=%s" % (pkg, dep))
+        args.add("--preferred=%s=%s" % (pkg, get_apparent_label(dep.label)))
 
     args.add_all(jarindex_files)
 
@@ -81,7 +83,7 @@ java_index = rule(
             doc = "list of java labels to be indexed without a JarSpec.Label, typically [@bazel_tools//tools/jdk:platformclasspath]",
             allow_files = True,
         ),
-        "preferred_deps": attr.string_dict(
+        "preferred_deps": attr.string_keyed_label_dict(
             doc = "mapping of package name to label that should be used for dependency resolution",
         ),
         "_mergeindex": attr.label(
@@ -95,13 +97,6 @@ java_index = rule(
             cfg = "exec",
             executable = True,
             doc = "the jarindexer tool",
-        ),
-        "_ijar": attr.label(
-            default = Label("@bazel_tools//tools/jdk:ijar"),
-            executable = True,
-            cfg = "exec",
-            allow_files = True,
-            doc = "the ijar tool",
         ),
     },
     outputs = {

--- a/rules/java_indexer_aspect.bzl
+++ b/rules/java_indexer_aspect.bzl
@@ -244,13 +244,21 @@ def _jarindex_basename(ctx, label):
 
 # see https://bazelbuild.slack.com/archives/C014RARENH0/p1752851984151199?thread_ts=1752594227.746349&cid=C014RARENH0 - we can't get the label apparent name! ("@maven")
 def get_apparent_label(label):
-    parts = label.repo_name.split("~")
+    # if label.repo_name.startswith("rules_jvm_external"):
+    #     fail("get_apparent_label:", str(label))
+
+    parts = label.repo_name.split("+")
     apparent_name = parts[len(parts) - 1]
     apparent_label = "@%s//%s:%s" % (apparent_name, label.package, label.name)
+
+    if apparent_name.startswith("rules_jvm_external"):
+        fail("apparent_name:", apparent_name)
+
     return apparent_label
 
 def jarindexer_action(ctx, label, kind, executable, jar):
     output_file = ctx.actions.declare_file(_jarindex_basename(ctx, label) + ".javaindex.pb")
+
     ctx.actions.run(
         mnemonic = "JarIndexer",
         progress_message = "Indexing " + jar.basename,
@@ -267,6 +275,7 @@ def jarindexer_action(ctx, label, kind, executable, jar):
         inputs = [jar],
         outputs = [output_file],
     )
+
     return output_file
 
 def collect_java_toolchain_info(target, ide_info, ide_info_file):

--- a/rules/java_indexer_aspect.bzl
+++ b/rules/java_indexer_aspect.bzl
@@ -60,6 +60,8 @@ COMPILE_TIME = 0
 
 RUNTIME = 1
 
+DEFAULT_REPO_NAME_SEPARATOR = "+"
+
 # Compile-time dependency attributes, grouped by type.
 DEPS = [
     "_cc_toolchain",  # From cc rules
@@ -244,15 +246,9 @@ def _jarindex_basename(ctx, label):
 
 # see https://bazelbuild.slack.com/archives/C014RARENH0/p1752851984151199?thread_ts=1752594227.746349&cid=C014RARENH0 - we can't get the label apparent name! ("@maven")
 def get_apparent_label(label):
-    # if label.repo_name.startswith("rules_jvm_external"):
-    #     fail("get_apparent_label:", str(label))
-
-    parts = label.repo_name.split("+")
+    parts = label.repo_name.split(DEFAULT_REPO_NAME_SEPARATOR)
     apparent_name = parts[len(parts) - 1]
     apparent_label = "@%s//%s:%s" % (apparent_name, label.package, label.name)
-
-    if apparent_name.startswith("rules_jvm_external"):
-        fail("apparent_name:", apparent_name)
 
     return apparent_label
 

--- a/rules/java_indexer_aspect.bzl
+++ b/rules/java_indexer_aspect.bzl
@@ -242,6 +242,13 @@ def _jarindex_basename(ctx, label):
         label.name,
     ])
 
+# see https://bazelbuild.slack.com/archives/C014RARENH0/p1752851984151199?thread_ts=1752594227.746349&cid=C014RARENH0 - we can't get the label apparent name! ("@maven")
+def get_apparent_label(label):
+    parts = label.repo_name.split("~")
+    apparent_name = parts[len(parts) - 1]
+    apparent_label = "@%s//%s:%s" % (apparent_name, label.package, label.name)
+    return apparent_label
+
 def jarindexer_action(ctx, label, kind, executable, jar):
     output_file = ctx.actions.declare_file(_jarindex_basename(ctx, label) + ".javaindex.pb")
     ctx.actions.run(
@@ -250,7 +257,7 @@ def jarindexer_action(ctx, label, kind, executable, jar):
         executable = executable,
         arguments = [
             "--label",
-            str(label),
+            get_apparent_label(label),
             "--kind",
             kind,
             "--output_file",


### PR DESCRIPTION
- Add LockfileV2 struct to parse rules_jvm_external v2 lockfile format
- Update NewResolver to try v2 format first, fallback to v1
- Sort artifact IDs for deterministic putSymbol iteration
- Add get_apparent_label() to convert canonical labels to apparent names (e.g., @@rules_jvm_external~5.3~maven -> @maven)
- Change preferred_deps to string_keyed_label_dict for proper label handling
- Rename CleanupLabel to CleanupLabelName for clarity
- Remove unused _ijar attribute from java_index rule
- Add unit tests for maven resolver